### PR TITLE
GET /lessons/:student_id renamed tests 

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -145,14 +145,14 @@ describe("GET /lessons/:student_id", ()=>{
     return request(app).get("/api/lessons/test").expect(400).then(({body}) =>{
       const {msg} = body;
       
-      expect(msg).toEqual("Bad request");
+      expect(msg).toEqual("Invalid input");
     })
   })
   test("404: Responds with not found when given bad student_id", ()=> {
     return request(app).get("/api/lessons/1000000").expect(404).then(({body}) => {
       const {msg} = body;
 
-      expect(msg).toEqual("Not found");
+      expect(msg).toEqual("not found");
     })
   })
 })


### PR DESCRIPTION
- Renamed tests error message for 404 and 400 to new message. 